### PR TITLE
--journal with explicit date uses wrong month & year folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ atlassian-ide-plugin.xml
 .metadata/
 projects/
 logs/
+issue*.groovy

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     "picocli",
     "println",
     "refman",
+    "sprintf",
     "taskdef",
     "tmpdir",
     "todir",

--- a/src/net/ebdon/webdoxy/JournalPage.groovy
+++ b/src/net/ebdon/webdoxy/JournalPage.groovy
@@ -2,6 +2,8 @@ package net.ebdon.webdoxy;
 
 import java.text.SimpleDateFormat;
 import java.time.temporal.IsoFields;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * @file
@@ -96,7 +98,14 @@ class JournalPage {
   }
 
   def createSkeletonHeader() {
+    final DateTimeFormatter commentFormatter =
+      DateTimeFormatter.ofPattern( '''EEE' 'yyyy'-'LL'-'dd' is in ISO 8601 week 'w' of year 'YYYY''')
+    final String pageDateComment =
+      pageDate.toZonedDateTime().format( commentFormatter )
+
+    logger.info pageDateComment
     append "@page ${pageAnchor} $title\n"
+    append "<!-- $pageDateComment -->\n"
     append "@anchor ${h1Anchor}"
     append "# $firstHeaderTitle\n"
   }

--- a/src/net/ebdon/webdoxy/JournalProject.groovy
+++ b/src/net/ebdon/webdoxy/JournalProject.groovy
@@ -80,10 +80,11 @@ class JournalProject extends Project {
   }
 
   def createPage( Date date ) {
+    logger.debug "Creating page for $date"
     pageDate = date
 
     logger.debug "fullFolderPath: $fullFolderPath"
-    logger.debug "Full path: $fullPath"
+    logger.debug "Full path for $date: $fullPath"
     ant.mkdir dir: fullFolderPath
 
     logger.info "Creating page file: $fullPath"
@@ -95,7 +96,7 @@ class JournalProject extends Project {
       page.create()
       addPageToMonth page
     } else {
-      logger.warn  message( 'JournalProject.nothingToDo' )
+      logger.warn  resource.message( 'JournalProject.nothingToDo' )
       logger.debug " --> ${pageFile.absolutePath}"
     }
   }

--- a/src/resources/log4j2.xml
+++ b/src/resources/log4j2.xml
@@ -19,7 +19,7 @@ limitations under the License.
 <Configuration status="WARN">
   <Properties>
     <Property name="logPath">logs</Property>
-    <Property name="logLevel">debug</Property>
+    <Property name="logLevel">info</Property>
     <Property name="filePattern">WebDoxy-test-%d{yyyy-MM-dd}.log</Property>
     <Property name="WebDoxyPattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %c{1} %msg%n</Property>
     <Property name="consolePattern">%-5level %msg%n</Property>

--- a/srcTest/net/ebdon/webdoxy/JournalProjectTest.groovy
+++ b/srcTest/net/ebdon/webdoxy/JournalProjectTest.groovy
@@ -1,7 +1,9 @@
 package net.ebdon.webdoxy;
 
 import groovy.test.GroovyTestCase;
+import java.time.ZonedDateTime;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import groovy.transform.TypeChecked;
 
 /**
@@ -34,14 +36,14 @@ class JournalProjectTest extends GroovyTestCase {
     ]
   ];
 
-  // @Override void setUp() {
   JournalProjectTest() {
-    final String regression63 = 'Issue #63 regression'
+    final String regression63 = 'Issue #63 regression, expected "anchorDay", not "anchor.day"'
     config.project.journal.format.metaClass.getAt = { String key ->
       switch (key) {
-        case 'shorter':    'dd-MMM-yyyy'; break
-        case 'anchorDay':  'yyyyMMdd'   ; break
-        case 'anchor.day':
+        case 'annual'    : 'YYYY';        break
+        case 'shorter'   : 'dd-MMM-yyyy'; break
+        case 'anchorDay' : 'yyyyMMdd'   ; break
+        case 'anchor.day': 
           logger.fatal regression63
           throw new Exception( regression63 )
         default:
@@ -57,5 +59,40 @@ class JournalProjectTest extends GroovyTestCase {
     final SimpleDateFormat sdfShorter = journalProject.dateFormatter( 'shorter' )
 
     assert sdfAd && sdfShorter
+  }
+
+  @TypeChecked
+  void testDateFormatterAnnual() {
+    final JournalProject journalProject = new JournalProject( 'test project', config )
+    final SimpleDateFormat annualFormatter = journalProject.dateFormatter( 'annual' )
+
+    logger.debug 'Year | formatted | Passed |         java.util.Date       | week-of-week-based-year'
+    logger.debug '-----|-----------|--------|------------------------------|------------------------'
+
+    final int javaYearOffset = 1900
+    int numFailed = 0
+    1998.upto(2001) { final Number targetYear ->
+      final int targetJavaYear = targetYear - javaYearOffset
+      final Date targetDate = new Date( targetJavaYear,0,1,20,0,0)
+      journalProject.pageDate = targetDate
+      final String formattedDate = annualFormatter.format( targetDate )
+      final String weekNumber = targetDate.
+        toZonedDateTime().format( DateTimeFormatter.ofPattern( 'w' ) )
+
+      assert weekNumber in ['1','52','53']
+      final String expectedYear = weekNumber == '1' ? "$targetYear" : "${targetYear - 1}"
+      final String passed = expectedYear == formattedDate ? 'Pass' : 'FAIL'
+      if ( passed != 'Pass' ) {
+        ++numFailed
+      }
+      logger.debug sprintf( '%-5s|    %-4s   |  %4s  | %s | %2s',
+        targetYear, formattedDate, passed, targetDate, weekNumber )
+    }
+    logger.debug "$numFailed errors detected"
+    if ( numFailed ) {
+      final String message = 'Issue #32 regression'
+      logger.fatal message
+      throw new Exception( message )
+    }
   }
 }

--- a/srcTest/net/ebdon/webdoxy/WebDoxyTest.groovy
+++ b/srcTest/net/ebdon/webdoxy/WebDoxyTest.groovy
@@ -173,14 +173,13 @@ class WebDoxyTest extends GroovyTestCase {
             assert expectedLocalDates[ currentPageNum ] == dateOfPageToCreate.toLocalDate()
           }
         }.addDiaryPage()
-        // build.addDiaryPage()
       }
     }
   }
 
   void testAddDiaryPageDefaultDate() {
     logger.debug 'Start of testAddDiaryPageDefaultDate()'
-      buildPages()
+    buildPages()
     logger.debug 'End of testAddDiaryPageDefaultDate()'
   }
 }


### PR DESCRIPTION
Fixes #32

Not really a bug. I'd fogotten that ISO 8601 week numbers are used.
This is configurable, in groovy..config, by changing the format from
'YYYY' (ISO 8601) to 'yyyy' (calendar week).

Top avoid confusion a comment is added to the generated page, and an
info level message is logged.